### PR TITLE
Use git worktree cmd instead of env var

### DIFF
--- a/fast_flake_update/__init__.py
+++ b/fast_flake_update/__init__.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -57,24 +56,22 @@ def main() -> None:
             sys.exit(0)
 
         source = Path(tmpdir) / "source"
-        source.mkdir()
-
-        env = os.environ.copy()
-        env["GIT_WORK_TREE"] = str(source)
 
         subprocess.run(
             [
                 "git",
                 "-C",
                 local_checkout,
-                "checkout",
-                "-f",
+                "worktree",
+                "add",
+                "-d",
+                source,
                 rev,
             ],
             check=True,
-            cwd=source,
-            env=env,
+            cwd=local_checkout,
         )
+
         out = subprocess.run(
             [
                 "git",
@@ -99,6 +96,20 @@ def main() -> None:
             check=True,
         )
         store_path = res.stdout.strip()
+
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                local_checkout,
+                "worktree",
+                "remove",
+                source,
+            ],
+            check=True,
+            cwd=local_checkout,
+        )
+
         res = subprocess.run(
             ["nix", "path-info", "--json", str(store_path)],
             check=True,


### PR DESCRIPTION
Using fast_flake_update results in leaving the local checkout in a 'detached HEAD' state instead of untouched.
Looks like setting GIT_WORK_TREE doesn't create a worktree anymore? Because of that the local checkout instead of the worktree gets changed. Using 'git worktree' fixes it.

The 'git worktree add' command creates the specified directory and performs a checkout into it, so no need to do it manually anymore.

Also calling 'git worktree remove' to not leaving any leftovers.

Fixes #53