### PR TITLE
build: python requires explicit `format` to build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,9 @@
           packages.fast-flake-update = pkgs.python3.pkgs.buildPythonPackage {
             pname = "fast-flake-update";
             version = "0.1.0";
+            pyproject = true;
             src = ./.;
+            build-system = [ pkgs.python3.pkgs.setuptools ];
             makeWrapperArgs = [
               "--prefix PATH : ${
                 pkgs.lib.makeBinPath [


### PR DESCRIPTION
The latest version of nixpkgs requires explicit `format` to be set when building a python package. This addresses that issue for the latest nixos-unstable and nixpkgs-unstable channels.

This patch does not bump the nixpkgs as there is already automation to handle that.

https://github.com/NixOS/nixpkgs/pull/421660 for reference